### PR TITLE
BLD: removal dependency of recursive fs.mkdirSync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@enigmampc/discovery-cli",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -117,6 +117,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.0.2.tgz",
       "integrity": "sha512-8/qcMh15507AnXJ3lBeuhsdFwnWQqnp68EpUuHlYPixJ5vjVmls7/Jq48cnUlrZI8Jd9U1jkhfCl0gaT5KMgVw=="
+    },
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "requires": {
+        "defer-to-connect": "^1.0.1"
+      }
     },
     "@types/bn.js": {
       "version": "4.11.5",
@@ -1442,6 +1455,35 @@
         }
       }
     },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+        }
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1528,6 +1570,11 @@
         "readdirp": "^2.0.0"
       }
     },
+    "chownr": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -1583,9 +1630,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.1.0.tgz",
-      "integrity": "sha512-8B00fJOEh1HPrx4fo5eW16XmE1PcL1tGpGrxy63CXGP9nHdPBN63X75hA1zhvQuhVztJWLqV58Roj2qlNM7cAA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.2.0.tgz",
+      "integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ=="
     },
     "cli-width": {
       "version": "2.2.0",
@@ -1616,6 +1663,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
     },
     "clui": {
       "version": "0.3.6",
@@ -2080,6 +2135,11 @@
       "requires": {
         "clone": "^1.0.2"
       }
+    },
+    "defer-to-connect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
+      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -3972,6 +4032,14 @@
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^2.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "requires": {
+        "minipass": "^2.2.1"
       }
     },
     "fs-promise": {
@@ -7843,15 +7911,32 @@
               "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "requires": {
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                 "ethereumjs-util": "^5.1.1"
               },
               "dependencies": {
                 "ethereumjs-abi": {
-                  "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
-                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+                  "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#8431eab7b3384e65e8126a4602520b78031666fb",
+                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                   "requires": {
-                    "bn.js": "^4.10.0",
-                    "ethereumjs-util": "^5.0.0"
+                    "bn.js": "^4.11.8",
+                    "ethereumjs-util": "^6.0.0"
+                  },
+                  "dependencies": {
+                    "ethereumjs-util": {
+                      "version": "6.1.0",
+                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+                      "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+                      "requires": {
+                        "bn.js": "^4.11.0",
+                        "create-hash": "^1.1.2",
+                        "ethjs-util": "0.1.6",
+                        "keccak": "^1.0.2",
+                        "rlp": "^2.0.0",
+                        "safe-buffer": "^5.1.1",
+                        "secp256k1": "^3.0.1"
+                      }
+                    }
                   }
                 }
               }
@@ -9294,8 +9379,7 @@
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "resolved": "",
           "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -15183,15 +15267,32 @@
               "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "requires": {
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                 "ethereumjs-util": "^5.1.1"
               },
               "dependencies": {
                 "ethereumjs-abi": {
-                  "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
-                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+                  "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#8431eab7b3384e65e8126a4602520b78031666fb",
+                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                   "requires": {
-                    "bn.js": "^4.10.0",
-                    "ethereumjs-util": "^5.0.0"
+                    "bn.js": "^4.11.8",
+                    "ethereumjs-util": "^6.0.0"
+                  },
+                  "dependencies": {
+                    "ethereumjs-util": {
+                      "version": "6.1.0",
+                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+                      "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+                      "requires": {
+                        "bn.js": "^4.11.0",
+                        "create-hash": "^1.1.2",
+                        "ethjs-util": "0.1.6",
+                        "keccak": "^1.0.2",
+                        "rlp": "^2.0.0",
+                        "safe-buffer": "^5.1.1",
+                        "secp256k1": "^3.0.1"
+                      }
+                    }
                   }
                 }
               }
@@ -15258,20 +15359,23 @@
           "optional": true,
           "requires": {
             "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.35"
+            "web3-core-helpers": "1.0.0-beta.35",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
           },
           "dependencies": {
             "debug": {
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "websocket": {
               "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-              "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+              "optional": true,
               "requires": {
                 "debug": "^2.2.0",
                 "nan": "^2.3.3",
@@ -16192,6 +16296,11 @@
         }
       }
     },
+    "http-cache-semantics": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -16797,6 +16906,11 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+    },
     "json-pointer": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.0.tgz",
@@ -16884,6 +16998,14 @@
         "sha3": "^1.2.2"
       }
     },
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -16955,9 +17077,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash-es": {
       "version": "4.17.11",
@@ -16980,9 +17102,9 @@
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.sum": {
       "version": "4.0.2",
@@ -17235,10 +17357,34 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -17489,6 +17635,11 @@
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
+    },
+    "normalize-url": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+      "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ=="
     },
     "npm-programmatic": {
       "version": "0.0.6",
@@ -18677,6 +18828,16 @@
         "lodash": "^4.17.11"
       }
     },
+    "request-promise-native": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+      "requires": {
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -18735,6 +18896,14 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -19308,9 +19477,9 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -19586,9 +19755,9 @@
       }
     },
     "solc": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.9.tgz",
-      "integrity": "sha512-IyCEXnSbpb3ii8FkgNu0QDtCtnvyGCtYNQejOaIZi6/9/CLJ2ozDHN2oNG26HfGZ8op9yDgqC+5SHziFvkRZuA==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.10.tgz",
+      "integrity": "sha512-Stdrh/MDkopsXYPRzPehTNYuV80Grr2CnQMuFvWj+EeRVbe3piGHxW47KebWn1sGdmK8FLaMfUehccqJP0KovQ==",
       "requires": {
         "command-exists": "^1.2.8",
         "fs-extra": "^0.30.0",
@@ -20105,6 +20274,11 @@
         "kind-of": "^3.0.2"
       }
     },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
+    },
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -20168,12 +20342,12 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "truffle-artifactor": {
-      "version": "4.0.20",
-      "resolved": "https://registry.npmjs.org/truffle-artifactor/-/truffle-artifactor-4.0.20.tgz",
-      "integrity": "sha512-IX+KvGNPkDQlMW1+9txYYn1+6IkvLPFiIh+hIjj2E7yYg9XS3zYxYbWg/wTcGyZsdtHwRVLOks7EvA0k+5LD1w==",
+      "version": "4.0.26",
+      "resolved": "https://registry.npmjs.org/truffle-artifactor/-/truffle-artifactor-4.0.26.tgz",
+      "integrity": "sha512-Ke5q3WYK8qV+B+Gr5RgxjzkN1Yf4G6DhxjcM6lUh6pdl08O2UDraRoA+Va39q1fh5Fr7kfTGUluL/RytXaCJIw==",
       "requires": {
         "fs-extra": "6.0.1",
-        "lodash": "4.17.11",
+        "lodash": "^4.17.13",
         "truffle-contract-schema": "^3.0.11"
       },
       "dependencies": {
@@ -20203,16 +20377,17 @@
       "integrity": "sha512-gVvagLCvYD0QXfnkxy6I48P6O+d7TEY0smc2VFuwldl1/clLVWE+KfBO/jFMaAz+nupTQeKvPhNTeyh3JAsCeA=="
     },
     "truffle-box": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/truffle-box/-/truffle-box-1.0.28.tgz",
-      "integrity": "sha512-mOmo2EdB0gUcV84pB6xPPhTsycLjjjz90kSd4V47IqJhx6dDSx6jEs/wBDNcA0gcEVf54x1IcuBgvnPZhH0wXw==",
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/truffle-box/-/truffle-box-1.0.33.tgz",
+      "integrity": "sha512-m+nzvRrS3HnmKixRaAJiXpoz5q4wabgjQgLKWmANH7hj4F8HV55IHnAbbm0TmzyUhqMWDwxDQqWDWOCTS3Zm+w==",
       "requires": {
         "fs-extra": "6.0.1",
         "github-download": "^0.5.0",
         "ora": "^3.0.0",
         "request": "^2.85.0",
+        "request-promise-native": "^1.0.7",
         "tmp": "0.0.33",
-        "truffle-config": "^1.1.13",
+        "truffle-config": "^1.1.17",
         "vcsurl": "^0.1.1"
       },
       "dependencies": {
@@ -20242,13 +20417,13 @@
       "integrity": "sha512-MtIusUMxJeJlOqoqda4DYJ86gqSGDVMGiqhVEVgHL2J5L4plci/uePgYROajklXE9H/g6u7yotnAKOhCdTB9/A=="
     },
     "truffle-compile": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/truffle-compile/-/truffle-compile-4.1.1.tgz",
-      "integrity": "sha512-b4XTcK2L/nb11ekeZy3Q4cx0DRaoqrZ4UQfd0cp6CXq3IVqMuEF+lNXjHnu+tIbzhMN2Zov1xV5DtoJC3vOJmw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/truffle-compile/-/truffle-compile-4.2.0.tgz",
+      "integrity": "sha512-o1JxJUgxogjw5YARm6VHR7CO/Odj2VQdsmKf9goT8zLMaL4QBPvp1t6xmFLOrMF4R/lwmJkQSgMffcHKQjk9ZA==",
       "requires": {
-        "async": "2.6.1",
         "colors": "^1.1.2",
         "debug": "^4.1.0",
+        "fs-extra": "^8.0.1",
         "ora": "^3.0.0",
         "original-require": "^1.0.1",
         "request": "^2.85.0",
@@ -20256,20 +20431,12 @@
         "require-from-string": "^2.0.2",
         "semver": "^5.6.0",
         "solc": "^0.5.0",
-        "truffle-config": "^1.1.13",
-        "truffle-contract-sources": "^0.1.4",
+        "truffle-config": "^1.1.17",
+        "truffle-contract-sources": "^0.1.5",
         "truffle-error": "^0.0.5",
         "truffle-expect": "^0.0.9"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-          "requires": {
-            "lodash": "^4.17.10"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -20278,23 +20445,55 @@
             "ms": "^2.1.1"
           }
         },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+          "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "truffle-contract-sources": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/truffle-contract-sources/-/truffle-contract-sources-0.1.5.tgz",
+          "integrity": "sha512-skhZ8s3sLM4PyRFqn8zbBWG2z1P5zX7ndQPYokr2aiez8o44x5hmUoPeiXgKlMYIyR1Y1zOyNpaVEZyBY1+4Cw==",
+          "requires": {
+            "debug": "^4.1.0",
+            "glob": "^7.1.2"
+          }
         }
       }
     },
     "truffle-compile-vyper": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/truffle-compile-vyper/-/truffle-compile-vyper-1.0.18.tgz",
-      "integrity": "sha512-MAsmYqY0eFklYtG3IBtBqlT0sibyq2yox2T356R1XGh/KpsFC1AbjyxsSTBL+pzpSb0ro3Fd2qZkluS1sSoijg==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/truffle-compile-vyper/-/truffle-compile-vyper-1.0.24.tgz",
+      "integrity": "sha512-FGdkURsW8Nc78h7pQI6ZX2icTJplDF0Ryp13KYJF33M6W0Xm2UTHzygLd6G8G+6fNx+oYrVlm+87ihiaHfahfw==",
       "requires": {
         "async": "2.6.1",
         "colors": "^1.1.2",
         "eslint": "^5.5.0",
         "minimatch": "^3.0.4",
-        "truffle-compile": "^4.1.1"
+        "truffle-compile": "^4.2.0"
       },
       "dependencies": {
         "async": {
@@ -20308,16 +20507,648 @@
       }
     },
     "truffle-config": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.1.13.tgz",
-      "integrity": "sha512-ZjaeDFQfWIuqZ2tb+pGw1YXuHfOtukz/+803Ukl5WahkUlpPXKM4I542GyKw+U5lWASFviH0L9zGM3DhKmF9qQ==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.1.17.tgz",
+      "integrity": "sha512-XayW+x0o3HrPY74UXkmD1kMhyRftXUzBb2UEE5aUnlLr4HEsY4OoJPoMecgwLoOqC3kRJNNXhHtJqJv6w9S1RA==",
       "requires": {
         "configstore": "^4.0.0",
         "find-up": "^2.1.0",
-        "lodash": "4.17.11",
+        "lodash": "^4.17.13",
         "original-require": "1.0.1",
         "truffle-error": "^0.0.5",
-        "truffle-provider": "^0.1.10"
+        "truffle-provider": "^0.1.13"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.14.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.14.tgz",
+          "integrity": "sha512-xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ=="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "elliptic": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "eth-lib": {
+          "version": "0.1.27",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
+          "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "keccakjs": "^0.2.1",
+            "nano-json-stream-parser": "^0.1.2",
+            "servify": "^0.1.12",
+            "ws": "^3.0.0",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+              "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            }
+          }
+        },
+        "ethers": {
+          "version": "4.0.33",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.33.tgz",
+          "integrity": "sha512-lAHkSPzBe0Vj+JrhmkEHLtUEKEheVktIjGDyE9gbzF4zf1vibjYgB57LraDHu4/ItqWVkztgsm8GWqcDMN+6vQ==",
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "got": {
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "oboe": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
+          "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
+          "requires": {
+            "http-https": "^1.0.0"
+          }
+        },
+        "p-cancelable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+          "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
+        "scrypt.js": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
+          "integrity": "sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==",
+          "requires": {
+            "scrypt": "^6.0.2",
+            "scryptsy": "^1.2.1"
+          }
+        },
+        "swarm-js": {
+          "version": "0.1.39",
+          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
+          "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
+          "requires": {
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "decompress": "^4.0.0",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^4.0.2",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar": "^4.0.2",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+            },
+            "got": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            },
+            "p-cancelable": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+              "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+            },
+            "prepend-http": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+              "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+            },
+            "url-parse-lax": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+              "requires": {
+                "prepend-http": "^1.0.1"
+              }
+            }
+          }
+        },
+        "tar": {
+          "version": "4.4.10",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+          "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.5",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
+          }
+        },
+        "truffle-interface-adapter": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/truffle-interface-adapter/-/truffle-interface-adapter-0.2.2.tgz",
+          "integrity": "sha512-dAKN+mSOlQV/+PlzUhBH90RAWrbp0Avm8nQcALoTwKa35PkS5RyB2ir1Y0AVoZvKVFYOmRDt884KHpZe8YgJRA==",
+          "requires": {
+            "bn.js": "^4.11.8",
+            "ethers": "^4.0.32",
+            "lodash": "^4.17.13",
+            "web3": "^1.2.0"
+          }
+        },
+        "truffle-provider": {
+          "version": "0.1.13",
+          "resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.1.13.tgz",
+          "integrity": "sha512-zbO8fNLCHfcDyaC2MI+l5eybN2aUGBpVoQcEHGov2U5LD2F6GJP8Vb3gf/Eqb//X3kZSKaUfGmy32hc87qxvBA==",
+          "requires": {
+            "truffle-error": "^0.0.5",
+            "truffle-interface-adapter": "^0.2.2",
+            "web3": "^1.2.0"
+          }
+        },
+        "underscore": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.0.tgz",
+          "integrity": "sha512-iFrVAexsopX97x0ofBU/7HrCxzovf624qBkjBUeHZDf/G3Sb4tMQtjkCRc5lgVvzureq5SCqDiFDcqnw7eJ0bA==",
+          "requires": {
+            "web3-bzz": "1.2.0",
+            "web3-core": "1.2.0",
+            "web3-eth": "1.2.0",
+            "web3-eth-personal": "1.2.0",
+            "web3-net": "1.2.0",
+            "web3-shh": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.0.tgz",
+          "integrity": "sha512-QEIdvguSEpqBK9b815nzx4yvpfKv/SAvaFeCMjQ0vjIVqFhAwBHDxd+f+X3nWGVRGVeOTP7864tau26CPBtQ8Q==",
+          "requires": {
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.0.tgz",
+          "integrity": "sha512-Vy+fargzx94COdihE79zIM5lb/XAl/LJlgGdmz2a6QhgGZrSL8K6DKKNS+OuORAcLJN2PWNMc4IdfknkOw1PhQ==",
+          "requires": {
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-requestmanager": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.0.tgz",
+          "integrity": "sha512-KLCCP2FS1cMz23Y9l3ZaEDzaUky+GpsNavl4Hn1xX8lNaKcfgGEF+DgtAY/TfPQYAxLjLrSbIFUDzo9H/W1WAQ==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.0.tgz",
+          "integrity": "sha512-Iff5rCL+sgHe6zZVZijp818aRixKQf3ZAyQsT6ewER1r9yqXsH89DJtX33Xw8xiaYSwUFcpNs2j+Kluhv/eVAw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-promievent": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.0.tgz",
+          "integrity": "sha512-9THNYsZka91AX4LZGZvka5hio9+QlOY22hNgCiagmCmYytyKk3cXftL6CWefnNF7XgW8sy/ew5lzWLVsQW61Lw==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.0.tgz",
+          "integrity": "sha512-hPe1jyESodXAiE7qJglu7ySo4GINCn5CgG+9G1ATLQbriZsir83QMSeKQekv/hckKFIf4SvZJRPEBhtAle+Dhw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0",
+            "web3-providers-http": "1.2.0",
+            "web3-providers-ipc": "1.2.0",
+            "web3-providers-ws": "1.2.0"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.0.tgz",
+          "integrity": "sha512-DHipGH8It5E4HxxvymhkudcYhBVgGx6MwGWobIVKFgp6JRxtuvAbqwrMbuD/+78J6yXOa4y9zVXBk12dm2NXGg==",
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.0.tgz",
+          "integrity": "sha512-GP1+hHS/IVW1tAOIDS44PxCpvSl9PBU/KAB40WgP27UMvSy43LjHxGlP6hQQOdIfmBLBTvGvn2n+Z5kW2gzAzg==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-eth-abi": "1.2.0",
+            "web3-eth-accounts": "1.2.0",
+            "web3-eth-contract": "1.2.0",
+            "web3-eth-ens": "1.2.0",
+            "web3-eth-iban": "1.2.0",
+            "web3-eth-personal": "1.2.0",
+            "web3-net": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.0.tgz",
+          "integrity": "sha512-FDuPq/tFeMg/D/f7cNSmvVYkMYb1z379gUUzSL8ZFtZrdHPkezq+lq/TmWmbCOMLYNXlhGJBzjGdLXRS4Upprg==",
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.0"
+          },
+          "dependencies": {
+            "ethers": {
+              "version": "4.0.0-beta.3",
+              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+              "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+              "requires": {
+                "@types/node": "^10.3.2",
+                "aes-js": "3.0.0",
+                "bn.js": "^4.4.0",
+                "elliptic": "6.3.3",
+                "hash.js": "1.1.3",
+                "js-sha3": "0.5.7",
+                "scrypt-js": "2.0.3",
+                "setimmediate": "1.0.4",
+                "uuid": "2.0.1",
+                "xmlhttprequest": "1.8.0"
+              }
+            },
+            "scrypt-js": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+              "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.0.tgz",
+          "integrity": "sha512-d/fUAL3F6HqstvEiBnZ1RwZ77/DytgF9d6A3mWVvPOUk2Pqi77PM0adRvsKvIWUaQ/k6OoCk/oXtbzaO7CyGpg==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scrypt.js": "^0.3.0",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-utils": "1.2.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+              "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.0.tgz",
+          "integrity": "sha512-hfjozNbfsoMeR3QklfkwU0Mqcw6YRD4y1Cb1ghGWNhFy2+/sbvKcQNPPJDKFTde22PRzGQBWyh/nb422Sux4bQ==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-promievent": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-eth-abi": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.0.tgz",
+          "integrity": "sha512-kE6uHMLwH9dv+MZSKT7BcKXcQ6CcLP5m5mM44s2zg2e9Rl20F3J6R3Ik6sLc/w2ywdCwTe/Z22yEstHXQwu5ig==",
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-promievent": "1.2.0",
+            "web3-eth-abi": "1.2.0",
+            "web3-eth-contract": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.0.tgz",
+          "integrity": "sha512-6DzTx/cvIgEvxadhJjLGpsuDUARA4RKskNOuwWYUsUODcPb50rsfMmRkHhGtLss/sNXVE5gNjbT9rX3TDqy2tg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.0.tgz",
+          "integrity": "sha512-8QdcaT6dbdiMC8zEqvDuij8XeI34r2GGdQYGvYBP2UgCm15EZBHgewxO30A+O+j2oIW1/Hu60zP5upnhCuA1Dw==",
+          "requires": {
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-net": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-net": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.0.tgz",
+          "integrity": "sha512-7iD8C6vvx8APXPMmlpPLGWjn4bsXHzd3BTdFzKjkoYjiiVFJdVAbY3j1BwN/6tVQu8Ay7sDpV2EdTNub7GKbyw==",
+          "requires": {
+            "web3-core": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.0.tgz",
+          "integrity": "sha512-UrUn6JSz7NVCZ+0nZZtC4cmbl5JIi57w1flL1jN8jgkfdWDdErNvTkSwCt/QYdTQscMaUtWXDDOSAsVO6YC64g==",
+          "requires": {
+            "web3-core-helpers": "1.2.0",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.0.tgz",
+          "integrity": "sha512-T2OSbiqu7+dahbGG5YFEQM5+FXdLVvaTCKmHXaQpw8IuL5hw7HELtyFOtHVudgDRyw0tJKxIfAiX/v2F1IL1fQ==",
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.0.tgz",
+          "integrity": "sha512-rnwGcCe6cev5A6eG5UBCQqPmkJVZMCrK+HN1AvUCco0OHD/0asGc9LuLbtkQIyznA6Lzetq/OOcaTOM4KeT11g==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0",
+            "websocket": "github:frozeman/WebSocket-Node#browserifyCompatible"
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.0.tgz",
+          "integrity": "sha512-VFjS8kvsQBodudFmIoVJWvDNZosONJZZnhvktngD3POu5dwbJmSCl6lzbLJ2C5XjR15dF+JvSstAkWbM+2sdPg==",
+          "requires": {
+            "web3-core": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-net": "1.2.0"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.0.tgz",
+          "integrity": "sha512-tI1low8ICoaWU2c53cikH0rsksKuIskI2nycH5E5sEXxxl9/BOD3CeDDBFbxgNPQ+bpDevbR7gXNEDB7Ud4G9g==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+              "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
+        },
+        "websocket": {
+          "version": "github:frozeman/WebSocket-Node#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "github:frozeman/WebSocket-Node#browserifyCompatible",
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
       }
     },
     "truffle-contract": {
@@ -20827,15 +21658,15 @@
       "integrity": "sha512-8ifOoAiRVHsmM8vsn4xATsa4zifTsRA3vt7rsz1ryP2JE+uUqavqQficdh2uVJoa/DIid6O7iZ7J1HtQsHikOQ=="
     },
     "truffle-external-compile": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/truffle-external-compile/-/truffle-external-compile-1.0.11.tgz",
-      "integrity": "sha512-s253KcXnd/Tzi+AZRWtD42GiMY8TKVwJt6WBQhFoXcC5IkwRAKOoBFNrG9mnoUB2hNv5Mopom5pYU9AhTepH9w==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/truffle-external-compile/-/truffle-external-compile-1.0.12.tgz",
+      "integrity": "sha512-uu8O0B6WQXpShBlJSriLTPpLg8XzvkKlejbvPitSRBooLXAjxmiTg8Yys3e3NhGgpp4S8CmXFYZw/hO3qPNnbA==",
       "requires": {
         "debug": "^4.1.0",
         "glob": "^7.1.2",
         "truffle-contract-schema": "^3.0.11",
         "truffle-expect": "^0.0.9",
-        "web3-utils": "1.0.0-beta.37"
+        "web3-utils": "^1.2.0"
       },
       "dependencies": {
         "debug": {
@@ -20846,10 +21677,44 @@
             "ms": "^2.1.1"
           }
         },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "underscore": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "web3-utils": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.0.tgz",
+          "integrity": "sha512-tI1low8ICoaWU2c53cikH0rsksKuIskI2nycH5E5sEXxxl9/BOD3CeDDBFbxgNPQ+bpDevbR7gXNEDB7Ud4G9g==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
@@ -20881,22 +21746,27 @@
       "integrity": "sha512-8ERMLiRewdLBCX4mFrGY23cv7AtcBMU/KryY3hz4I4itOcfnd75FQFO9sIeSw86puBJA5mFqu0CcjP9u91ehrQ=="
     },
     "truffle-migrate": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/truffle-migrate/-/truffle-migrate-3.0.22.tgz",
-      "integrity": "sha512-saTphMwl8oG95N3HqYettzkh7jjLfBR/Z40Pp087OL84YbqGpLxGXzfW6vF37IRs0UZfE0Ip0Py5VFIXRdgvmw==",
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/truffle-migrate/-/truffle-migrate-3.0.28.tgz",
+      "integrity": "sha512-3NJ0Q3srjrOtexAZ75Z6W9QdiHHkcnC3vObwl1K+bDzspNpMVWJT54X1iyBwYTdUO4bgSth6cVZeBgG++Le/UA==",
       "requires": {
         "async": "2.6.1",
         "emittery": "^0.4.0",
         "node-dir": "0.1.17",
-        "truffle-config": "^1.1.13",
-        "truffle-deployer": "^3.0.22",
+        "truffle-config": "^1.1.17",
+        "truffle-deployer": "^3.0.28",
         "truffle-expect": "^0.0.9",
-        "truffle-interface-adapter": "^0.1.6",
-        "truffle-reporters": "^1.0.10",
-        "truffle-require": "^2.0.13",
-        "web3": "1.0.0-beta.37"
+        "truffle-interface-adapter": "^0.2.2",
+        "truffle-reporters": "^1.0.11",
+        "truffle-require": "^2.0.17",
+        "web3": "^1.2.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "10.14.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.14.tgz",
+          "integrity": "sha512-xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ=="
+        },
         "async": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
@@ -20904,6 +21774,648 @@
           "requires": {
             "lodash": "^4.17.10"
           }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "elliptic": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "eth-lib": {
+          "version": "0.1.27",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
+          "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "keccakjs": "^0.2.1",
+            "nano-json-stream-parser": "^0.1.2",
+            "servify": "^0.1.12",
+            "ws": "^3.0.0",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+              "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            }
+          }
+        },
+        "ethers": {
+          "version": "4.0.33",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.33.tgz",
+          "integrity": "sha512-lAHkSPzBe0Vj+JrhmkEHLtUEKEheVktIjGDyE9gbzF4zf1vibjYgB57LraDHu4/ItqWVkztgsm8GWqcDMN+6vQ==",
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "got": {
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "oboe": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
+          "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
+          "requires": {
+            "http-https": "^1.0.0"
+          }
+        },
+        "p-cancelable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+          "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
+        "scrypt.js": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
+          "integrity": "sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==",
+          "requires": {
+            "scrypt": "^6.0.2",
+            "scryptsy": "^1.2.1"
+          }
+        },
+        "swarm-js": {
+          "version": "0.1.39",
+          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
+          "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
+          "requires": {
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "decompress": "^4.0.0",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^4.0.2",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar": "^4.0.2",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+            },
+            "got": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            },
+            "p-cancelable": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+              "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+            },
+            "prepend-http": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+              "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+            },
+            "url-parse-lax": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+              "requires": {
+                "prepend-http": "^1.0.1"
+              }
+            }
+          }
+        },
+        "tar": {
+          "version": "4.4.10",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+          "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.5",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
+          }
+        },
+        "truffle-contract": {
+          "version": "4.0.27",
+          "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-4.0.27.tgz",
+          "integrity": "sha512-/UwsAm8tHN6sGCRbM/sarp/eR5ST3aj45wvmKWh680H3H60ur66xzrDgKJ0xPCpnAZhBOaNIhTY2bGj3jZz/ZQ==",
+          "requires": {
+            "bignumber.js": "^7.2.1",
+            "ethers": "^4.0.0-beta.1",
+            "truffle-blockchain-utils": "^0.0.10",
+            "truffle-contract-schema": "^3.0.11",
+            "truffle-error": "^0.0.5",
+            "truffle-interface-adapter": "^0.2.2",
+            "web3": "^1.2.0",
+            "web3-core-promievent": "^1.2.0",
+            "web3-eth-abi": "^1.2.0",
+            "web3-utils": "^1.2.0"
+          }
+        },
+        "truffle-deployer": {
+          "version": "3.0.28",
+          "resolved": "https://registry.npmjs.org/truffle-deployer/-/truffle-deployer-3.0.28.tgz",
+          "integrity": "sha512-vdwzqLPHWl2uMaVLVoDqqrIATt/8pCqCEGcDVuvqMqvvOxAolyidDWomxoJ4e+bY/rapq5NQrgFYqUpKccok8w==",
+          "requires": {
+            "emittery": "^0.4.0",
+            "truffle-contract": "^4.0.27",
+            "truffle-expect": "^0.0.9"
+          }
+        },
+        "truffle-interface-adapter": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/truffle-interface-adapter/-/truffle-interface-adapter-0.2.2.tgz",
+          "integrity": "sha512-dAKN+mSOlQV/+PlzUhBH90RAWrbp0Avm8nQcALoTwKa35PkS5RyB2ir1Y0AVoZvKVFYOmRDt884KHpZe8YgJRA==",
+          "requires": {
+            "bn.js": "^4.11.8",
+            "ethers": "^4.0.32",
+            "lodash": "^4.17.13",
+            "web3": "^1.2.0"
+          }
+        },
+        "underscore": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.0.tgz",
+          "integrity": "sha512-iFrVAexsopX97x0ofBU/7HrCxzovf624qBkjBUeHZDf/G3Sb4tMQtjkCRc5lgVvzureq5SCqDiFDcqnw7eJ0bA==",
+          "requires": {
+            "web3-bzz": "1.2.0",
+            "web3-core": "1.2.0",
+            "web3-eth": "1.2.0",
+            "web3-eth-personal": "1.2.0",
+            "web3-net": "1.2.0",
+            "web3-shh": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.0.tgz",
+          "integrity": "sha512-QEIdvguSEpqBK9b815nzx4yvpfKv/SAvaFeCMjQ0vjIVqFhAwBHDxd+f+X3nWGVRGVeOTP7864tau26CPBtQ8Q==",
+          "requires": {
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.0.tgz",
+          "integrity": "sha512-Vy+fargzx94COdihE79zIM5lb/XAl/LJlgGdmz2a6QhgGZrSL8K6DKKNS+OuORAcLJN2PWNMc4IdfknkOw1PhQ==",
+          "requires": {
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-requestmanager": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.0.tgz",
+          "integrity": "sha512-KLCCP2FS1cMz23Y9l3ZaEDzaUky+GpsNavl4Hn1xX8lNaKcfgGEF+DgtAY/TfPQYAxLjLrSbIFUDzo9H/W1WAQ==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.0.tgz",
+          "integrity": "sha512-Iff5rCL+sgHe6zZVZijp818aRixKQf3ZAyQsT6ewER1r9yqXsH89DJtX33Xw8xiaYSwUFcpNs2j+Kluhv/eVAw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-promievent": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.0.tgz",
+          "integrity": "sha512-9THNYsZka91AX4LZGZvka5hio9+QlOY22hNgCiagmCmYytyKk3cXftL6CWefnNF7XgW8sy/ew5lzWLVsQW61Lw==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.0.tgz",
+          "integrity": "sha512-hPe1jyESodXAiE7qJglu7ySo4GINCn5CgG+9G1ATLQbriZsir83QMSeKQekv/hckKFIf4SvZJRPEBhtAle+Dhw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0",
+            "web3-providers-http": "1.2.0",
+            "web3-providers-ipc": "1.2.0",
+            "web3-providers-ws": "1.2.0"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.0.tgz",
+          "integrity": "sha512-DHipGH8It5E4HxxvymhkudcYhBVgGx6MwGWobIVKFgp6JRxtuvAbqwrMbuD/+78J6yXOa4y9zVXBk12dm2NXGg==",
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.0.tgz",
+          "integrity": "sha512-GP1+hHS/IVW1tAOIDS44PxCpvSl9PBU/KAB40WgP27UMvSy43LjHxGlP6hQQOdIfmBLBTvGvn2n+Z5kW2gzAzg==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-eth-abi": "1.2.0",
+            "web3-eth-accounts": "1.2.0",
+            "web3-eth-contract": "1.2.0",
+            "web3-eth-ens": "1.2.0",
+            "web3-eth-iban": "1.2.0",
+            "web3-eth-personal": "1.2.0",
+            "web3-net": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.0.tgz",
+          "integrity": "sha512-FDuPq/tFeMg/D/f7cNSmvVYkMYb1z379gUUzSL8ZFtZrdHPkezq+lq/TmWmbCOMLYNXlhGJBzjGdLXRS4Upprg==",
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.0"
+          },
+          "dependencies": {
+            "ethers": {
+              "version": "4.0.0-beta.3",
+              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+              "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+              "requires": {
+                "@types/node": "^10.3.2",
+                "aes-js": "3.0.0",
+                "bn.js": "^4.4.0",
+                "elliptic": "6.3.3",
+                "hash.js": "1.1.3",
+                "js-sha3": "0.5.7",
+                "scrypt-js": "2.0.3",
+                "setimmediate": "1.0.4",
+                "uuid": "2.0.1",
+                "xmlhttprequest": "1.8.0"
+              }
+            },
+            "scrypt-js": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+              "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.0.tgz",
+          "integrity": "sha512-d/fUAL3F6HqstvEiBnZ1RwZ77/DytgF9d6A3mWVvPOUk2Pqi77PM0adRvsKvIWUaQ/k6OoCk/oXtbzaO7CyGpg==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scrypt.js": "^0.3.0",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-utils": "1.2.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+              "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.0.tgz",
+          "integrity": "sha512-hfjozNbfsoMeR3QklfkwU0Mqcw6YRD4y1Cb1ghGWNhFy2+/sbvKcQNPPJDKFTde22PRzGQBWyh/nb422Sux4bQ==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-promievent": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-eth-abi": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.0.tgz",
+          "integrity": "sha512-kE6uHMLwH9dv+MZSKT7BcKXcQ6CcLP5m5mM44s2zg2e9Rl20F3J6R3Ik6sLc/w2ywdCwTe/Z22yEstHXQwu5ig==",
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-promievent": "1.2.0",
+            "web3-eth-abi": "1.2.0",
+            "web3-eth-contract": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.0.tgz",
+          "integrity": "sha512-6DzTx/cvIgEvxadhJjLGpsuDUARA4RKskNOuwWYUsUODcPb50rsfMmRkHhGtLss/sNXVE5gNjbT9rX3TDqy2tg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.0.tgz",
+          "integrity": "sha512-8QdcaT6dbdiMC8zEqvDuij8XeI34r2GGdQYGvYBP2UgCm15EZBHgewxO30A+O+j2oIW1/Hu60zP5upnhCuA1Dw==",
+          "requires": {
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-net": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-net": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.0.tgz",
+          "integrity": "sha512-7iD8C6vvx8APXPMmlpPLGWjn4bsXHzd3BTdFzKjkoYjiiVFJdVAbY3j1BwN/6tVQu8Ay7sDpV2EdTNub7GKbyw==",
+          "requires": {
+            "web3-core": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.0.tgz",
+          "integrity": "sha512-UrUn6JSz7NVCZ+0nZZtC4cmbl5JIi57w1flL1jN8jgkfdWDdErNvTkSwCt/QYdTQscMaUtWXDDOSAsVO6YC64g==",
+          "requires": {
+            "web3-core-helpers": "1.2.0",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.0.tgz",
+          "integrity": "sha512-T2OSbiqu7+dahbGG5YFEQM5+FXdLVvaTCKmHXaQpw8IuL5hw7HELtyFOtHVudgDRyw0tJKxIfAiX/v2F1IL1fQ==",
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.0.tgz",
+          "integrity": "sha512-rnwGcCe6cev5A6eG5UBCQqPmkJVZMCrK+HN1AvUCco0OHD/0asGc9LuLbtkQIyznA6Lzetq/OOcaTOM4KeT11g==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0",
+            "websocket": "github:frozeman/WebSocket-Node#browserifyCompatible"
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.0.tgz",
+          "integrity": "sha512-VFjS8kvsQBodudFmIoVJWvDNZosONJZZnhvktngD3POu5dwbJmSCl6lzbLJ2C5XjR15dF+JvSstAkWbM+2sdPg==",
+          "requires": {
+            "web3-core": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-net": "1.2.0"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.0.tgz",
+          "integrity": "sha512-tI1low8ICoaWU2c53cikH0rsksKuIskI2nycH5E5sEXxxl9/BOD3CeDDBFbxgNPQ+bpDevbR7gXNEDB7Ud4G9g==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+              "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
+        },
+        "websocket": {
+          "version": "github:frozeman/WebSocket-Node#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "github:frozeman/WebSocket-Node#browserifyCompatible",
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },
@@ -20923,25 +22435,683 @@
       "integrity": "sha512-XSzD4Tj1T16E8qwoIHnQ9sOuvoemP1yqxX9Jg0VvvoLTdl8X17uau6dN08JgNR09hJroTrXPbkAi5Y8IfKhVMw=="
     },
     "truffle-reporters": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/truffle-reporters/-/truffle-reporters-1.0.10.tgz",
-      "integrity": "sha512-ZKw6keXlQU2i/r+GoHgZb78YXZLxJ0RfQ/lSOlnZU4gvhaNaMdgU4l9ehDh3sjWSemkb7kaQbG7jG8T566WXzg==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/truffle-reporters/-/truffle-reporters-1.0.11.tgz",
+      "integrity": "sha512-k+gc6PokNE3qMyvzteURZpRkVepKg853qwq1bG/R9k4xuaP5fFlyfCL/7pAKzFX7NNRLY6JkcK8jU9yVPT3CqA==",
       "requires": {
         "node-emoji": "^1.8.1",
         "ora": "^3.0.0",
-        "web3-utils": "1.0.0-beta.37"
+        "web3-utils": "^1.2.0"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "underscore": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "web3-utils": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.0.tgz",
+          "integrity": "sha512-tI1low8ICoaWU2c53cikH0rsksKuIskI2nycH5E5sEXxxl9/BOD3CeDDBFbxgNPQ+bpDevbR7gXNEDB7Ud4G9g==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "truffle-require": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/truffle-require/-/truffle-require-2.0.13.tgz",
-      "integrity": "sha512-OkQzGgb7H+N7XpscJMJ/3E8BAcqVVjB4vaL07mzdHDgFBJ6E3LnXBL+/RZw72UAeKLsdgEYL3zpPy/wlV1WPIA==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/truffle-require/-/truffle-require-2.0.17.tgz",
+      "integrity": "sha512-H49nSMH9uc7Hy7WOmqXd/NRLffMl3CEeQZFS9N+jH7o2hCMNK8ZjwHcb+8XJ4Rku4r6un77WfrIN3+jaYGiTQQ==",
       "requires": {
         "original-require": "1.0.1",
-        "truffle-config": "^1.1.13",
+        "truffle-config": "^1.1.17",
         "truffle-expect": "^0.0.9",
-        "truffle-interface-adapter": "^0.1.6",
-        "web3": "1.0.0-beta.37"
+        "truffle-interface-adapter": "^0.2.2",
+        "web3": "^1.2.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.14.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.14.tgz",
+          "integrity": "sha512-xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ=="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "elliptic": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "eth-lib": {
+          "version": "0.1.27",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
+          "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "keccakjs": "^0.2.1",
+            "nano-json-stream-parser": "^0.1.2",
+            "servify": "^0.1.12",
+            "ws": "^3.0.0",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+              "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            }
+          }
+        },
+        "ethers": {
+          "version": "4.0.33",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.33.tgz",
+          "integrity": "sha512-lAHkSPzBe0Vj+JrhmkEHLtUEKEheVktIjGDyE9gbzF4zf1vibjYgB57LraDHu4/ItqWVkztgsm8GWqcDMN+6vQ==",
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "got": {
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "oboe": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
+          "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
+          "requires": {
+            "http-https": "^1.0.0"
+          }
+        },
+        "p-cancelable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+          "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
+        "scrypt.js": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
+          "integrity": "sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==",
+          "requires": {
+            "scrypt": "^6.0.2",
+            "scryptsy": "^1.2.1"
+          }
+        },
+        "swarm-js": {
+          "version": "0.1.39",
+          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
+          "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
+          "requires": {
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "decompress": "^4.0.0",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^4.0.2",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar": "^4.0.2",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+            },
+            "got": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            },
+            "p-cancelable": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+              "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+            },
+            "prepend-http": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+              "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+            },
+            "url-parse-lax": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+              "requires": {
+                "prepend-http": "^1.0.1"
+              }
+            }
+          }
+        },
+        "tar": {
+          "version": "4.4.10",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+          "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.5",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
+          }
+        },
+        "truffle-interface-adapter": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/truffle-interface-adapter/-/truffle-interface-adapter-0.2.2.tgz",
+          "integrity": "sha512-dAKN+mSOlQV/+PlzUhBH90RAWrbp0Avm8nQcALoTwKa35PkS5RyB2ir1Y0AVoZvKVFYOmRDt884KHpZe8YgJRA==",
+          "requires": {
+            "bn.js": "^4.11.8",
+            "ethers": "^4.0.32",
+            "lodash": "^4.17.13",
+            "web3": "^1.2.0"
+          }
+        },
+        "underscore": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.0.tgz",
+          "integrity": "sha512-iFrVAexsopX97x0ofBU/7HrCxzovf624qBkjBUeHZDf/G3Sb4tMQtjkCRc5lgVvzureq5SCqDiFDcqnw7eJ0bA==",
+          "requires": {
+            "web3-bzz": "1.2.0",
+            "web3-core": "1.2.0",
+            "web3-eth": "1.2.0",
+            "web3-eth-personal": "1.2.0",
+            "web3-net": "1.2.0",
+            "web3-shh": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.0.tgz",
+          "integrity": "sha512-QEIdvguSEpqBK9b815nzx4yvpfKv/SAvaFeCMjQ0vjIVqFhAwBHDxd+f+X3nWGVRGVeOTP7864tau26CPBtQ8Q==",
+          "requires": {
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.0.tgz",
+          "integrity": "sha512-Vy+fargzx94COdihE79zIM5lb/XAl/LJlgGdmz2a6QhgGZrSL8K6DKKNS+OuORAcLJN2PWNMc4IdfknkOw1PhQ==",
+          "requires": {
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-requestmanager": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.0.tgz",
+          "integrity": "sha512-KLCCP2FS1cMz23Y9l3ZaEDzaUky+GpsNavl4Hn1xX8lNaKcfgGEF+DgtAY/TfPQYAxLjLrSbIFUDzo9H/W1WAQ==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.0.tgz",
+          "integrity": "sha512-Iff5rCL+sgHe6zZVZijp818aRixKQf3ZAyQsT6ewER1r9yqXsH89DJtX33Xw8xiaYSwUFcpNs2j+Kluhv/eVAw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-promievent": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.0.tgz",
+          "integrity": "sha512-9THNYsZka91AX4LZGZvka5hio9+QlOY22hNgCiagmCmYytyKk3cXftL6CWefnNF7XgW8sy/ew5lzWLVsQW61Lw==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.0.tgz",
+          "integrity": "sha512-hPe1jyESodXAiE7qJglu7ySo4GINCn5CgG+9G1ATLQbriZsir83QMSeKQekv/hckKFIf4SvZJRPEBhtAle+Dhw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0",
+            "web3-providers-http": "1.2.0",
+            "web3-providers-ipc": "1.2.0",
+            "web3-providers-ws": "1.2.0"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.0.tgz",
+          "integrity": "sha512-DHipGH8It5E4HxxvymhkudcYhBVgGx6MwGWobIVKFgp6JRxtuvAbqwrMbuD/+78J6yXOa4y9zVXBk12dm2NXGg==",
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.0.tgz",
+          "integrity": "sha512-GP1+hHS/IVW1tAOIDS44PxCpvSl9PBU/KAB40WgP27UMvSy43LjHxGlP6hQQOdIfmBLBTvGvn2n+Z5kW2gzAzg==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-eth-abi": "1.2.0",
+            "web3-eth-accounts": "1.2.0",
+            "web3-eth-contract": "1.2.0",
+            "web3-eth-ens": "1.2.0",
+            "web3-eth-iban": "1.2.0",
+            "web3-eth-personal": "1.2.0",
+            "web3-net": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.0.tgz",
+          "integrity": "sha512-FDuPq/tFeMg/D/f7cNSmvVYkMYb1z379gUUzSL8ZFtZrdHPkezq+lq/TmWmbCOMLYNXlhGJBzjGdLXRS4Upprg==",
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.0"
+          },
+          "dependencies": {
+            "ethers": {
+              "version": "4.0.0-beta.3",
+              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+              "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+              "requires": {
+                "@types/node": "^10.3.2",
+                "aes-js": "3.0.0",
+                "bn.js": "^4.4.0",
+                "elliptic": "6.3.3",
+                "hash.js": "1.1.3",
+                "js-sha3": "0.5.7",
+                "scrypt-js": "2.0.3",
+                "setimmediate": "1.0.4",
+                "uuid": "2.0.1",
+                "xmlhttprequest": "1.8.0"
+              }
+            },
+            "scrypt-js": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+              "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.0.tgz",
+          "integrity": "sha512-d/fUAL3F6HqstvEiBnZ1RwZ77/DytgF9d6A3mWVvPOUk2Pqi77PM0adRvsKvIWUaQ/k6OoCk/oXtbzaO7CyGpg==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scrypt.js": "^0.3.0",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-utils": "1.2.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+              "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.0.tgz",
+          "integrity": "sha512-hfjozNbfsoMeR3QklfkwU0Mqcw6YRD4y1Cb1ghGWNhFy2+/sbvKcQNPPJDKFTde22PRzGQBWyh/nb422Sux4bQ==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-promievent": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-eth-abi": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.0.tgz",
+          "integrity": "sha512-kE6uHMLwH9dv+MZSKT7BcKXcQ6CcLP5m5mM44s2zg2e9Rl20F3J6R3Ik6sLc/w2ywdCwTe/Z22yEstHXQwu5ig==",
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-promievent": "1.2.0",
+            "web3-eth-abi": "1.2.0",
+            "web3-eth-contract": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.0.tgz",
+          "integrity": "sha512-6DzTx/cvIgEvxadhJjLGpsuDUARA4RKskNOuwWYUsUODcPb50rsfMmRkHhGtLss/sNXVE5gNjbT9rX3TDqy2tg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.0.tgz",
+          "integrity": "sha512-8QdcaT6dbdiMC8zEqvDuij8XeI34r2GGdQYGvYBP2UgCm15EZBHgewxO30A+O+j2oIW1/Hu60zP5upnhCuA1Dw==",
+          "requires": {
+            "web3-core": "1.2.0",
+            "web3-core-helpers": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-net": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-net": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.0.tgz",
+          "integrity": "sha512-7iD8C6vvx8APXPMmlpPLGWjn4bsXHzd3BTdFzKjkoYjiiVFJdVAbY3j1BwN/6tVQu8Ay7sDpV2EdTNub7GKbyw==",
+          "requires": {
+            "web3-core": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-utils": "1.2.0"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.0.tgz",
+          "integrity": "sha512-UrUn6JSz7NVCZ+0nZZtC4cmbl5JIi57w1flL1jN8jgkfdWDdErNvTkSwCt/QYdTQscMaUtWXDDOSAsVO6YC64g==",
+          "requires": {
+            "web3-core-helpers": "1.2.0",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.0.tgz",
+          "integrity": "sha512-T2OSbiqu7+dahbGG5YFEQM5+FXdLVvaTCKmHXaQpw8IuL5hw7HELtyFOtHVudgDRyw0tJKxIfAiX/v2F1IL1fQ==",
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.0.tgz",
+          "integrity": "sha512-rnwGcCe6cev5A6eG5UBCQqPmkJVZMCrK+HN1AvUCco0OHD/0asGc9LuLbtkQIyznA6Lzetq/OOcaTOM4KeT11g==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.0",
+            "websocket": "github:frozeman/WebSocket-Node#browserifyCompatible"
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.0.tgz",
+          "integrity": "sha512-VFjS8kvsQBodudFmIoVJWvDNZosONJZZnhvktngD3POu5dwbJmSCl6lzbLJ2C5XjR15dF+JvSstAkWbM+2sdPg==",
+          "requires": {
+            "web3-core": "1.2.0",
+            "web3-core-method": "1.2.0",
+            "web3-core-subscriptions": "1.2.0",
+            "web3-net": "1.2.0"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.0.tgz",
+          "integrity": "sha512-tI1low8ICoaWU2c53cikH0rsksKuIskI2nycH5E5sEXxxl9/BOD3CeDDBFbxgNPQ+bpDevbR7gXNEDB7Ud4G9g==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.0",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+              "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
+        },
+        "websocket": {
+          "version": "github:frozeman/WebSocket-Node#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "github:frozeman/WebSocket-Node#browserifyCompatible",
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
       }
     },
     "truffle-resolver": {
@@ -20972,18 +23142,39 @@
       "integrity": "sha512-Rf9KLx8BFTX6/1jxKuzWC5AegSMTN9uxLIKWP38oBAxHq/ilD64W+W5eyEqBxAXUYlAABj9jpOg4Pn5NRYtxOg=="
     },
     "truffle-workflow-compile": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/truffle-workflow-compile/-/truffle-workflow-compile-2.0.20.tgz",
-      "integrity": "sha512-XyUW5DTmnsCF9149/0kgUkRPe5gBzCb7W8FfjqXsUuGMKbSqucb+yMOU7qidSsl7NGiDBekWoR4G5Li6Z5k21g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/truffle-workflow-compile/-/truffle-workflow-compile-2.1.0.tgz",
+      "integrity": "sha512-OxZg2VyI+jlxqnNYMOCcxUOITdU30+ZLWuSz7PXqCcy3JvwqoXz01I3JBt+BFzqiJyTLkggM741gqx7Oh1ywKg==",
       "requires": {
+        "fs-extra": "^7.0.1",
         "mkdirp": "^0.5.1",
-        "truffle-artifactor": "^4.0.20",
-        "truffle-compile": "^4.1.1",
-        "truffle-compile-vyper": "^1.0.18",
-        "truffle-config": "^1.1.13",
+        "truffle-artifactor": "^4.0.26",
+        "truffle-compile": "^4.2.0",
+        "truffle-compile-vyper": "^1.0.24",
+        "truffle-config": "^1.1.17",
         "truffle-expect": "^0.0.9",
-        "truffle-external-compile": "^1.0.11",
+        "truffle-external-compile": "^1.0.12",
         "truffle-resolver": "^5.0.14"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
       }
     },
     "tslib": {
@@ -21101,35 +23292,14 @@
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enigmampc/discovery-cli",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "A command-line interface for the Enigma Protocol developer environment",
   "main": "src/index.js",
   "scripts": {

--- a/src/deps.js
+++ b/src/deps.js
@@ -122,8 +122,12 @@ module.exports.compile = async function() {
   const folderSC = path.join(baseFolder, constants.FOLDER.SECRET_CONTRACTS);
   const secretContracts = fs.readdirSync(folderSC, {withFileTypes: true}).filter(f => f.isDirectory()).map(f => f.name);
   const buildFolderSC = path.join(baseFolder, constants.FOLDER.BUILD, constants.FOLDER.SECRET_CONTRACTS);
+
+  if (!fs.existsSync(path.join(baseFolder, constants.FOLDER.BUILD))) {
+    fs.mkdirSync(path.join(baseFolder, constants.FOLDER.BUILD));
+  }
   if (!fs.existsSync(buildFolderSC)){
-    fs.mkdirSync(buildFolderSC, {recursive: true});
+    fs.mkdirSync(buildFolderSC);
   }
   for(let i in secretContracts) {
     console.log(`Compiling Secret Contract "${secretContracts[i]}"...`)

--- a/src/index.js
+++ b/src/index.js
@@ -69,8 +69,8 @@ async function downloadFiles() {
       fs.writeFileSync(constants.FILE.DOCKER_COMPOSE_SW, r2.data);
       fs.writeFileSync(`${constants.FOLDER.SECRET_CONTRACTS}/${constants.FILE.CARGO_TOML}.template`, r3.data);
       let sampleContractFolder = path.join(constants.FOLDER.SECRET_CONTRACTS, constants.FOLDER.SAMPLE_CONTRACT);
-      if (!fs.existsSync(sampleContractFolder)) {
-        fs.mkdirSync(path.join(sampleContractFolder,'src'), {recursive: true});
+      if (!fs.existsSync(path.join(sampleContractFolder,'src'))) {
+        fs.mkdirSync(path.join(sampleContractFolder,'src'));
       }
       fs.writeFileSync(path.join(sampleContractFolder,'src/lib.rs'), r4.data);
       fs.writeFileSync(path.join(sampleContractFolder, constants.FILE.CARGO_TOML), r3.data);
@@ -99,11 +99,17 @@ function createFolders() {
   if (!fs.existsSync(constants.FOLDER.SECRET_CONTRACTS)){
     fs.mkdirSync(constants.FOLDER.SECRET_CONTRACTS);
   }
+  if (!fs.existsSync(path.join(constants.FOLDER.SECRET_CONTRACTS, constants.FOLDER.SAMPLE_CONTRACT))){
+    fs.mkdirSync(path.join(constants.FOLDER.SECRET_CONTRACTS, constants.FOLDER.SAMPLE_CONTRACT));
+  }
+  if (!fs.existsSync(constants.FOLDER.BUILD)){
+    fs.mkdirSync(path.join(constants.FOLDER.BUILD));
+  }
   if (!fs.existsSync(path.join(constants.FOLDER.BUILD, constants.FOLDER.SMART_CONTRACTS))){
-    fs.mkdirSync(path.join(constants.FOLDER.BUILD, constants.FOLDER.SMART_CONTRACTS), {recursive: true});
+    fs.mkdirSync(path.join(constants.FOLDER.BUILD, constants.FOLDER.SMART_CONTRACTS));
   }
   if (!fs.existsSync(path.join(constants.FOLDER.BUILD, constants.FOLDER.ENIGMA_CONTRACTS))){
-    fs.mkdirSync(path.join(constants.FOLDER.BUILD, constants.FOLDER.ENIGMA_CONTRACTS), {recursive: true});
+    fs.mkdirSync(path.join(constants.FOLDER.BUILD, constants.FOLDER.ENIGMA_CONTRACTS));
   }
   if (!fs.existsSync(constants.FOLDER.MIGRATIONS)){
     fs.mkdirSync(constants.FOLDER.MIGRATIONS);


### PR DESCRIPTION
Prior versions depended on `fs.mkdirSync(targetDir, { recursive: true });` (where the emphasis is on `recursive:true` that was introduced in Node `10.12.0` as per this [StackOverflow thread](https://stackoverflow.com/questions/31645738/how-to-create-full-path-with-nodes-fs-mkdirsync/40686853#40686853)). This dependency came up as an issue for users running older versions of Node as documented in [this forum post](https://forum.enigma.co/t/recommended-version-of-node-js-for-discovery-cli/911/2) and [this other one](https://forum.enigma.co/t/possible-issue-with-discovery-init-node-version-resolved/1027).

This PR removes this dependency, making the code more widely compatible.
