### PR TITLE
Fixpath

### DIFF
--- a/config/2_deploy_contracts.js
+++ b/config/2_deploy_contracts.js
@@ -57,7 +57,7 @@ async function deploySecretContract(config){
   var result = await enigma.admin.isDeployed(scTask.scAddr);
   if(result) {
 
-    fs.writeFile(path.join('../test/',config.filename.replace(/\.wasm$/, '.txt')), scTask.scAddr, 'utf8', function(err) {
+    fs.writeFile(path.resolve(migrationsFolder, '../test/', config.filename.replace(/\.wasm$/, '.txt')), scTask.scAddr, 'utf8', function(err) {
       if(err) {
         return console.log(err);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@enigmampc/discovery-cli",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enigmampc/discovery-cli",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "A command-line interface for the Enigma Protocol developer environment",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
The migrations script file stores on disk the enigma address of the example `simple_addition` contract, which then the test script later retrieves to send a computation to. The path for that file was relative, but was wrong, and now has been fixed consistently with how other relative paths are handled in that same file.