### PR TITLE
DEV: remove no_mangle

### DIFF
--- a/config/lib.rs
+++ b/config/lib.rs
@@ -29,11 +29,8 @@ pub trait ContractInterface{
 
 // The implementation of the exported ESC functions should be defined in the trait implementation 
 // for a new struct. 
-// #[no_mangle] modifier is required before each function to turn off Rust's name mangling, so that
-// it is easier to link to. Sets the symbol for this item to its identifier.
 pub struct Contract;
 impl ContractInterface for Contract {
-    #[no_mangle]
     fn addition(x: U256, y: U256) -> U256 {
         x + y
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enigmampc/discovery-cli",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "A command-line interface for the Enigma Protocol developer environment",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
`no_mangle` directive does not affect the functionality of the program. The secret contract functions are addressed by a procedural macro `pub_interface` by their names. Compilation names does not matter.