### PR TITLE
BLD: -y option for pull

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@enigmampc/discovery-cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enigmampc/discovery-cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A command-line interface for the Enigma Protocol developer environment",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
`discovery pull` now accepts an optional parameter `-y` to bypass the confirmation prompt to pull the docker images so that one can run:
`discovery pull -y`

This does not affect `discovery init`.

And version bump to `0.1.4`