### PR TITLE
BLD: moved around check to create build folder

### DIFF
--- a/src/deps.js
+++ b/src/deps.js
@@ -86,13 +86,16 @@ module.exports.findBasePath = function(){
     }
   }
 
-  const buildFolder = path.join(folderFound, constants.FOLDER.BUILD);
-  if (!fs.existsSync(buildFolder)){
-    fs.mkdirSync(buildFolder);
-  }
+
   
   if (folderFound &&
-      fs.readdirSync(folderFound).filter(f => /^secret_contracts$/.test(f)).length) {
+      fs.readdirSync(folderFound).filter(f => /^secret_contracts$/.test(f)).length &&
+      fs.readdirSync(folderFound).filter(f => /^smart_contracts$/.test(f)).length) {
+
+    const buildFolder = path.join(folderFound, constants.FOLDER.BUILD);
+    if (!fs.existsSync(buildFolder)){
+      fs.mkdirSync(buildFolder);
+    }
     return folderFound;
   } else {
     console.log('Cannot find the expected directory structure.');


### PR DESCRIPTION
Adjustes #31 so that:
- adds check for `smart_contracts` folder in addition to `secret_contracts` (because this function gets called before `compile` and compile needs to have both folders in place.
- moves the creation of the `build` folder if it does not exist when it has certainty that we are in the right place, otherwise a `build` folder may be created if a `discovery` command is run outside of the user's project.